### PR TITLE
fix: fetch join으로 N + 1 문제 해결

### DIFF
--- a/src/main/kotlin/com/group/libraryapp/domain/user/UserRepository.kt
+++ b/src/main/kotlin/com/group/libraryapp/domain/user/UserRepository.kt
@@ -1,9 +1,13 @@
 package com.group.libraryapp.domain.user
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface UserRepository : JpaRepository<User, Long> {
 
     fun findByName(name: String): User?
+
+    @Query("select distinct u from User u left join fetch u.userLoanHistories")
+    fun findAllWithHistories(): List<User>
 
 }

--- a/src/main/kotlin/com/group/libraryapp/service/user/UserService.kt
+++ b/src/main/kotlin/com/group/libraryapp/service/user/UserService.kt
@@ -45,7 +45,7 @@ class UserService(
 
     @Transactional(readOnly = true)
     fun getUserLoanHistories(): List<UserLoanHistoryResponse> {
-        return userRepository.findAll().map { user ->
+        return userRepository.findAllWithHistories().map { user ->
             UserLoanHistoryResponse(
                 name = user.name,
                 books = user.userLoanHistories.map { history ->


### PR DESCRIPTION
## Issue 번호
#1 


## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 리펙토링
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 코드 스타일 업데이트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


## 작업 사항
- User 데이터만 최초 1회 가져온 다음 각 User 별로 UserLoanHistory 정보들을 추가로 가져오는 N + 1 문제를 해결하기 위해 fetch join을 사용하여 해결
- fetch join을 통해서 UserLoanHistory 정보를 가져와, 실제 UserLoanHistory 객체를 만들어줌